### PR TITLE
Propogate errors if atuinResult has an error

### DIFF
--- a/main.go
+++ b/main.go
@@ -347,6 +347,10 @@ func fzfPreview(data string) error {
 		}
 
 		for r := range results {
+			if r.Error != nil {
+				return err
+			}
+
 			dirDisplay := shortenHome(r.Directory)
 			if r.Directory == cwd {
 				dirDisplay = "(same cwd)"


### PR DESCRIPTION
This also avoids using atuinResult as a map key if the error is
non-nil, which can fail if the error is not hashable.